### PR TITLE
Resolve issues with array type being returned as false

### DIFF
--- a/formidable-forms-encryption.php
+++ b/formidable-forms-encryption.php
@@ -100,7 +100,7 @@ function ff_acf_get_options() {
  */
 function ff_acf_array_flatten( $array ) {
 	if ( !is_array( $array ) ) {
-		return FALSE;
+		return array();
 	}
 	$result = array();
 	foreach ( $array as $key => $value ) {


### PR DESCRIPTION
The false value generates a fatal error. The logic was updated to return an empty array() instead.